### PR TITLE
Fixed error in action-log

### DIFF
--- a/tiddlers/SetupGitBranch.tid
+++ b/tiddlers/SetupGitBranch.tid
@@ -1,11 +1,11 @@
 created: 20220807194657760
-modified: 20220807202146170
+modified: 20220809024812563
 tags: $:/tags/StartupAction/PostRender
 title: SetupGitBranch
 type: text/vnd.tiddlywiki
 
 <$let branch={{{ [[GitBranchInfo]get[ref]split[/]last[]!match[master]!match[main]] }}}>
-<$action-log $$message="Extracted branch from ref" filter="branch" />
+<$action-log $$message="Extracted branch from ref" $$filter="branch" />
 <$action-setfield $tiddler="GitBranchInfo" $field="branch" $value=<<branch>> />
 <$action-sendmessage
   $message="tm-rename-tiddler"


### PR DESCRIPTION
Was missing $$ in front of filter attribute. 

Can't fix order - file cannot be renamed before setting the branch field.

Can't fix #6, but did fix a typo in an action-log parameter name.